### PR TITLE
Factored out the mail sending backend and added SMTP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,16 +40,35 @@ NB: Required parameters are: `email`, `name` and `message`. Other parameters wil
 Privacy concerns?
 -----------------
 
-Spin up your own free [Heroku](http://www.heroku.com) instance. A [Mandrill](http://mandrill.com) account required for email delivery.
+Spin up your own free [Heroku](http://www.heroku.com) instance. Email can be delivered via [Mandrill](http://mandrill.com) (An account is required) or
+authenticated SMTP over SSL.
+
+Setup with Mandrill:
 
 ```bash
     $ git clone https://github.com/samdobson/fwdform.git
     $ heroku create
+    $ heroku config:set FWDFORM_BACKEND=mandrill
     $ heroku config:set MANDRILL_API_KEY=<KEY>
     $ heroku addons:add heroku-postgresql:dev
     $ heroku pg:promote HEROKU_POSTGRESQL_COLOR
     $ heroku ps:scale web=1
 ```
+
+Setup with SMTP:
+
+```bash
+    $ git clone https://github.com/samdobson/fwdform.git
+    $ heroku create
+    $ heroku config:set FWDFORM_BACKEND=smtp
+    $ heroku config:set FWDFORM_SMTPHOST=<SMTPHOST>
+    $ heroku config:set FWDFORM_SMTPUSERNAME=<LOGIN>
+    $ heroku config:set FWDFORM_SMTPPASSWORD=<PWD>
+    $ heroku addons:add heroku-postgresql:dev
+    $ heroku pg:promote HEROKU_POSTGRESQL_COLOR
+    $ heroku ps:scale web=1
+```
+
 
 Deploy the application to your Heroku instance.
 

--- a/backends.py
+++ b/backends.py
@@ -67,7 +67,7 @@ class SMTPBackend(object):
                 raise Exception("Please set FWDFORM_SMTPUSERNAME and FWDFORM_SMTPPASSWORD environment variables or specify credentials in netrc")
 
 
-        self.username, _, self.pwd = auth
+            self.username, _, self.pwd = auth
 
     def send_message(self, to, from_email, subject, text):
         """Sends a message, returns True on success"""        

--- a/backends.py
+++ b/backends.py
@@ -1,0 +1,94 @@
+#-*- coding: utf-8 -*-
+
+from __future__ import unicode_literals, print_function, absolute_import
+
+import os
+
+from email.mime.application import MIMEApplication
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from email.utils import COMMASPACE, formatdate
+import smtplib
+
+
+# for documentation only:
+class BackendAPI(object):
+    def __init__(self):
+        """set everything up. fail here on missing configuration."""
+        pass
+
+    def send_message(self, to, from_email, subject, text):
+        """send a single message to single to address"""
+        pass
+
+class MandrillBackend(object):
+
+    def __init__(self):
+        try:
+            from mandrill import Mandrill
+        except ImportError:
+            raise Exception('Add mandrill to requirements.txt and pip install -r again to use mandrill')
+
+        try:
+            self.client = Mandrill(os.environ['MANDRILL_API_KEY'])
+        except KeyError:
+            raise Exception('Environment variable MANDRILL_API_KEY missing for mandrill backend')
+
+    def send_message(self, to, from_email, subject, text):
+        """Sends a message, returns True on success"""        
+
+        message = {
+               'to': [{'email': to}],
+               'from_email': from_email,
+               'subject': subject,
+               'text': text,
+        }
+
+        result = self.client.messages.send(message=message)
+        return result[0]['status'] == 'sent'
+        
+        
+class SMTPBackend(object):
+    """Send Mail via authenticated SMTP with configuration via environment or .netrc
+    """
+    def __init__(self):
+        self.host = os.environ.get('FWDFORM_SMTPHOST')
+        if not self.host:
+            raise Exception("Prese set FWDFORM_SMTPHOST environment variable")
+
+        self.username = os.environ.get('FWDFORM_SMTPUSERNAME')
+        self.pwd = os.environ.get('FWDFORM_SMTPPASSWORD')
+        
+
+        if not self.username or not self.pwd:
+            import netrc
+            auth = netrc.netrc().authenticators(self.host)
+            if not auth:
+                raise Exception("Please set FWDFORM_SMTPUSERNAME and FWDFORM_SMTPPASSWORD environment variables or specify credentials in netrc")
+
+
+        self.username, _, self.pwd = auth
+
+    def send_message(self, to, from_email, subject, text):
+        """Sends a message, returns True on success"""        
+
+        msg = MIMEText(text, 'plain', 'utf8')
+        msg['Subject'] = subject
+        msg['To'] = to
+        msg['From'] = from_email
+        
+        s = smtplib.SMTP_SSL()
+        s.connect(host=self.host)
+        s.login(self.username, self.pwd)
+        try:
+            s.sendmail(from_email, [to,], msg.as_string())
+        except smtplib.SMTPException:
+            return False
+        finally:
+            s.quit()   
+
+        return True
+
+backends = dict(mandrill=MandrillBackend,
+                smtp=SMTPBackend)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ itsdangerous==0.23
 mandrill==1.0.53
 psycopg2==2.5.2
 requests==2.2.1
-wsgiref==0.1.2
+


### PR DESCRIPTION
I did not test the heroku stuff yet. It works locally and I'm deploying to my own dokku server. I don't see why it shouldn't work though.
Existing installations would need to add the FWDFORM_BACKEND=mandrill variable to their environment. Rethinking this, 'mandrill' should probably the default to not break existing installations.
